### PR TITLE
Provide Tweet.OrderedMedia to keep the original order of tweet media

### DIFF
--- a/types.go
+++ b/types.go
@@ -39,6 +39,17 @@ type (
 		URL     string
 	}
 
+	MediaType string
+
+	// UnifiedMedia type represent a simplified ExtendedMedia
+	UnifiedMedia struct {
+		ID      string
+		Type    MediaType
+		URL     string
+		Preview *string
+		HLSURL  *string
+	}
+
 	// Tweet type.
 	Tweet struct {
 		ConversationID    string
@@ -75,6 +86,7 @@ type (
 		Videos            []Video
 		Views             int
 		SensitiveContent  bool
+		OrderedMedia      []UnifiedMedia // OrderedMedia keep the original order of media with mixed types
 	}
 
 	// ProfileResult of scrapping.
@@ -296,4 +308,10 @@ type (
 		CanHighlightTweets bool   `json:"can_highlight_tweets"`
 		HighlightedTweets  string `json:"highlighted_tweets"`
 	}
+)
+
+const (
+	MediaTypePhoto MediaType = "photo"
+	MediaTypeVideo MediaType = "video"
+	MediaTypeGIF   MediaType = "animated_gif"
 )

--- a/util.go
+++ b/util.go
@@ -234,12 +234,18 @@ func parseLegacyTweet(user *legacyUser, tweet *legacyTweet) *Tweet {
 	}
 
 	for _, media := range tweet.ExtendedEntities.Media {
+		unifiedMedia := UnifiedMedia{
+			ID:   media.IDStr,
+			Type: MediaType(media.Type),
+		}
+
 		if media.Type == "photo" {
 			photo := Photo{
 				ID:  media.IDStr,
 				URL: media.MediaURLHttps,
 			}
 
+			unifiedMedia.URL = photo.URL
 			tw.Photos = append(tw.Photos, photo)
 		} else if media.Type == "video" {
 			video := Video{
@@ -258,6 +264,9 @@ func parseLegacyTweet(user *legacyUser, tweet *legacyTweet) *Tweet {
 				}
 			}
 
+			unifiedMedia.URL = video.URL
+			unifiedMedia.Preview = &video.Preview
+			unifiedMedia.HLSURL = &video.HLSURL
 			tw.Videos = append(tw.Videos, video)
 		} else if media.Type == "animated_gif" {
 			gif := GIF{
@@ -278,8 +287,12 @@ func parseLegacyTweet(user *legacyUser, tweet *legacyTweet) *Tweet {
 				}
 			}
 
+			unifiedMedia.Preview = &gif.Preview
+			unifiedMedia.URL = gif.URL
 			tw.GIFs = append(tw.GIFs, gif)
 		}
+
+		tw.OrderedMedia = append(tw.OrderedMedia, unifiedMedia)
 
 		if !tw.SensitiveContent {
 			sensitive := media.ExtSensitiveMediaWarning


### PR DESCRIPTION
Currently the Tweet struct has separate field for Photos, Videos and GIFs, which is easier for use.

But for a tweet with different kind of media, this approach lost the original order of the media, so this PR try to give back the order with a OrderedMedia field which is an array of UnifiedMedia type.